### PR TITLE
Make local work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ This way both the local and slack adapters can share these.
 To run locally (after running a good ol' `npm i` of course):
 
 ```sh
-npm start
+npm run local
 ```
 
 To run on Slack:

--- a/adapters/_loadDataLocal.js
+++ b/adapters/_loadDataLocal.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird');
 
-export default () => new Promise(resolve => {
+module.exports = () => new Promise(resolve => {
   const items = require('../data/example_items.json');
   const areas = require('../data/example_areas.json');
   const doors = require('../data/example_doors.json');


### PR DESCRIPTION
Update readme on how to start the local adapter + fix _loadDataLocal.js which is somehow using ES6-style module syntax